### PR TITLE
fix register message when catch error + protected routes

### DIFF
--- a/FE/src/components/layout/header.tsx
+++ b/FE/src/components/layout/header.tsx
@@ -6,7 +6,7 @@ import cartIcon from '@/assets/cart-icon.svg'
 import defaultAvatar from '@/assets/default-avatar-icon.svg'
 import { Link, useNavigate } from 'react-router'
 import { Dropdown, Avatar } from 'antd'
-import { UserOutlined, LogoutOutlined } from '@ant-design/icons'
+import { UserOutlined, LogoutOutlined, SettingOutlined } from '@ant-design/icons'
 import { useAuthContext } from '@/contexts/AuthContext'
 import { removeTokens } from '@/services/auth/auth.service'
 
@@ -25,15 +25,32 @@ export const Header = () => {
             logout();
         } else if (key === 'profile') {
             // Navigate to profile page
+            navigate('/client')
+        }
+        else if (key === 'adminpage') {
+            navigate('/admin');
+        }
+        else if (key === 'sellerpage') {
+            navigate('/seller')
         }
     };
 
     const menuItems = [
-        {
+        ...(user && user.role === 'CUSTOMER' ? [{
             key: 'profile',
             label: 'Thông tin cá nhân',
             icon: <UserOutlined />
-        },
+        }] : []),
+        ...(user && user.role === 'ADMIN' ? [{
+            key: 'adminpage',
+            label: 'Quản trị viên',
+            icon: <SettingOutlined />
+        }] : []),
+        ...(user && user.role === 'STAFF' ? [{
+            key: 'sellerpage',
+            label: 'Nhân viên',
+            icon: <SettingOutlined />
+        }] : []),
         {
             type: 'divider' as const,
         },
@@ -42,7 +59,8 @@ export const Header = () => {
             label: 'Đăng xuất',
             icon: <LogoutOutlined />,
             danger: true
-        }
+        },
+
     ];
 
     return (

--- a/FE/src/pages/auth/register.tsx
+++ b/FE/src/pages/auth/register.tsx
@@ -75,7 +75,7 @@ export const RegisterPage = () => {
             setStep(2);
             setSuccess('OTP đã được gửi đến email của bạn');
         } catch (err: any) {
-            setError(err.response?.data?.error || 'Gửi OTP thất bại');
+            setError(err.response.data.message || 'Gửi OTP thất bại');
         } finally {
             setLoading(false);
         }
@@ -99,7 +99,7 @@ export const RegisterPage = () => {
             setSuccess('Đăng ký thành công! Đang chuyển hướng đến trang đăng nhập...');
             setTimeout(() => navigate('/login'), 1000);
         } catch (err: any) {
-            setError(err.response?.data?.error || 'Đăng ký thất bại');
+            setError(err.response.data.message || 'Đăng ký thất bại');
         } finally {
             setLoading(false);
         }
@@ -113,7 +113,7 @@ export const RegisterPage = () => {
             await authAPI.sendOtp({ email: emailForOtp });
             setSuccess('OTP đã được gửi lại');
         } catch (err: any) {
-            setError(err.response?.data?.error || 'Gửi OTP thất bại');
+            setError(err.response.data.message || 'Gửi OTP thất bại');
         } finally {
             setLoading(false);
         }

--- a/FE/src/routes/protected.route.tsx
+++ b/FE/src/routes/protected.route.tsx
@@ -1,0 +1,20 @@
+import { useAuthContext } from "@/contexts/AuthContext"
+import { Navigate } from "react-router"
+
+interface IProps {
+    children: React.ReactNode
+    allow?: Role | null
+    restrictedForAuthenticated?: boolean
+}
+
+export const ProtectedRoute = ({
+    children,
+    allow = null,
+    restrictedForAuthenticated = false
+}: IProps): React.ReactNode => {
+    const { user, isLoggedIn } = useAuthContext();
+    if ((restrictedForAuthenticated && isLoggedIn) || (isLoggedIn && user && user.role !== allow) || !isLoggedIn && allow) {
+        return <Navigate to={'/'} replace />
+    }
+    return <>{children} </>
+}

--- a/FE/src/routes/route.tsx
+++ b/FE/src/routes/route.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, Navigate } from "react-router";
+import { createBrowserRouter, Navigate, type RouteObject } from "react-router";
 import { AppLayout } from "@/layout";
 import { LoginPage } from "@/pages/auth/login";
 import { ConfirmPage } from "@/pages/auth/confirm";
@@ -24,58 +24,41 @@ import { OrderClient } from "@/pages/client/order";
 import { PaymentClient } from "@/pages/client/payment";
 import { OrderSuccess } from "@/pages/client/order-success";
 import { RegisterPage } from "@/pages/auth/register";
+import { ProtectedRoute } from "./protected.route";
 
-export const router = createBrowserRouter([
+const authRoutes: RouteObject[] = [
     {
-        path: "/",
-        element: <AppLayout />,
+        path: '/',
+        element: <ProtectedRoute restrictedForAuthenticated={true}><AppLayout /></ProtectedRoute>,
         children: [
-            {
-                index: true,
-                element: <div className="h-screen">This is homepage</div>
-            },
             {
                 path: '/login',
                 element: <LoginPage />
             },
             {
-                path: '/user-confirm',
+                path: 'register',
+                element: <RegisterPage />
+            },
+            {
+                path: 'user-confirm',
                 element: <ConfirmPage />
             },
             {
-                path: '/otp',
+                path: 'otp',
                 element: <OtpPage />
             },
             {
-                path: '/reset-pass',
+                path: 'reset-pass',
                 element: <ResetPasswordPage />
             },
-            {
-                path: '/seller/order/:id',
-                element: <DetailPage />
-            },
-            {
-                path: '/client/order/:id',
-                element: <OrderClient />
-            },
-            {
-                path: '/client/order/payment',
-                element: <PaymentClient />
-            },
-            {
-                path: '/client/order/success',
-                element: <OrderSuccess />
-            },
-            {
-                path: '/register',
-                element: <RegisterPage />
-            }
         ]
-    },
-    // seller route 
+    }
+]
+
+const sellerRoutes: RouteObject[] = [
     {
         path: '/seller',
-        element: <SellerLayout />,
+        element: <ProtectedRoute allow="STAFF"><SellerLayout /></ProtectedRoute>,
         children: [
             {
                 index: true,
@@ -95,9 +78,12 @@ export const router = createBrowserRouter([
             },
         ]
     },
+]
+
+const clientRoutes: RouteObject[] = [
     {
         path: '/client',
-        element: <ClientLayout />,
+        element: <ProtectedRoute allow={'CUSTOMER'}><ClientLayout /></ProtectedRoute>,
         children: [
             {
                 index: true,
@@ -122,11 +108,13 @@ export const router = createBrowserRouter([
 
         ]
 
-    },
-    // admin
+    }
+]
+
+const adminRoutes: RouteObject[] = [
     {
         path: '/admin',
-        element: <AdminLayout />,
+        element: <ProtectedRoute allow="ADMIN"><AdminLayout /></ProtectedRoute>,
         children: [
             {
                 index: true,
@@ -146,4 +134,38 @@ export const router = createBrowserRouter([
             }
         ]
     }
+]
+
+export const router = createBrowserRouter([
+    {
+        path: "/",
+        element: <AppLayout />,
+        children: [
+            {
+                index: true,
+                element: <div className="h-screen">This is homepage</div>
+            },
+            {
+                path: '/seller/order/:id',
+                element: <DetailPage />
+            },
+            {
+                path: '/client/order/:id',
+                element: <OrderClient />
+            },
+            {
+                path: '/client/order/payment',
+                element: <PaymentClient />
+            },
+            {
+                path: '/client/order/success',
+                element: <OrderSuccess />
+            },
+
+        ]
+    },
+    ...authRoutes,
+    ...sellerRoutes,
+    ...clientRoutes,
+    ...adminRoutes,
 ]);

--- a/FE/src/services/auth/auth.service.ts
+++ b/FE/src/services/auth/auth.service.ts
@@ -30,8 +30,9 @@ export const authAPI = {
         return response.data.data;
     },
 
-    sendOtp: async (data: SendOtpRequest): Promise<void> => {
-        await axios.post('/auth/send-otp', data);
+    sendOtp: async (data: SendOtpRequest) => {
+        const result = await axios.post<ApiResponse<any>>('/auth/send-otp', data);
+        return result.data;
     }
 };
 

--- a/FE/src/types/global.d.ts
+++ b/FE/src/types/global.d.ts
@@ -9,12 +9,14 @@ declare global {
         error?: string;
     }
 
+    type Role = 'STAFF' | 'CUSTOMER' | 'ADMIN'
+
     interface IUser {
         "id": string,
         "full_name": string,
         "email": string,
         "phone": string,
-        "role": string,
+        "role": Role,
         "is_active": boolean,
         "avatar": string,
         "create_at": Date,


### PR DESCRIPTION
- Sửa thông báo khi bị lỗi khi đăng kí tài khoản (vibe coding mà ko để ý T_T)
- Nhóm route lại thành từng nhóm cho dễ quản lí -> protected route
+ Vai trò nào thì chỉ được vào route  cho phép -> client ko thể vào admin và ngược lại, tương tụ với seller
+ guest chỉ có thể vào route dc public -> ko có protected route thì vào đc
- Một số route vẫn chưa bọc bảo vệ,...
- THêm type role : 'Customer' | 'STAFF' | 'ADMIN' cho trùng với backend
- Sửa header: Applayout => sau khi tất cả người dùng đăng nhập thành công đều đc chuyển tới root bất kể vai trò là gì, header đã được chỉnh sửa cho phù hợp với từng role  (note: chỉ có Applayout mới sửa, mấy cái còn lại thì chưa),,....